### PR TITLE
add optional secret generation for license keys.

### DIFF
--- a/charts/netobserv/Chart.yaml
+++ b/charts/netobserv/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: netobserv
 description: ElastiFlow NetObserv
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: 6.4.3
 
 keywords:

--- a/charts/netobserv/templates/deployment.yaml
+++ b/charts/netobserv/templates/deployment.yaml
@@ -40,6 +40,13 @@ spec:
           {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.license.createSecret -}}
+            - name: EF_FLOW_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: netobserv-license
+                  key: license
+          {{- end }}
           ports:
             - name: udp
               containerPort: {{ .Values.service.port }}

--- a/charts/netobserv/templates/secrets.yaml
+++ b/charts/netobserv/templates/secrets.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.license.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.license.secretRef | default "netobserv-license" }}
+  labels:
+    {{- include "netobserv.labels" . | nindent 4 }}
+type: Opaque
+data:
+  license: {{ .Values.license.licenseKey }}
+{{- end }}

--- a/charts/netobserv/values.yaml
+++ b/charts/netobserv/values.yaml
@@ -67,6 +67,14 @@ env:
   # EF_OUTPUT_GENERIC_HTTP_ADDRESSES: ''
   # EF_OUTPUT_RISKIQ_ENABLE: 'false'
 
+license:
+  # Specifies whether a secret should be created. If you don't have a license, no need to create a license secret.
+  createSecret: false
+  # Secret name to be used for the license. If empty, the secret name defaults to `netobserv-license`
+  # If no secret with a matching name exists, the value will be set from `licenseKey`.instead.
+  secretRef: ""
+  # Set license key, if not set, value from secret will be used
+  licenseKey: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
# Description
To enable licensing, this optionally creates a licensing secret that contains the license key. As a user, you should be able to set `license.createSecret: true` and pass a license key via helm's `--set` option. for example:

```
--set=license.createSecret=True --set=license.licenseKey=thisisanexamplelicensekey
```