### PR TITLE
fix whitespace removal when adding license secret env var.

### DIFF
--- a/charts/netobserv/Chart.yaml
+++ b/charts/netobserv/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: netobserv
 description: ElastiFlow NetObserv
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: 6.4.3
 
 keywords:

--- a/charts/netobserv/templates/deployment.yaml
+++ b/charts/netobserv/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.license.createSecret -}}
+          {{- if .Values.license.createSecret }}
             - name: EF_FLOW_LICENSE_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
# Description
This resolves an issue where the chart would fail to create a valid deployment due to the license secret being inline with the last env var added.
