### PR TITLE
ENG-1780: base64 encode license key strings

### DIFF
--- a/charts/netobserv/Chart.yaml
+++ b/charts/netobserv/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: netobserv
 description: ElastiFlow NetObserv
 type: application
-version: 0.0.10
+version: 0.0.11
 appVersion: 6.4.3
 
 keywords:

--- a/charts/netobserv/templates/secrets.yaml
+++ b/charts/netobserv/templates/secrets.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "netobserv.labels" . | nindent 4 }}
 type: Opaque
 data:
-  license: {{ .Values.license.licenseKey }}
+  license: {{ .Values.license.licenseKey | b64enc }}
 {{- end }}


### PR DESCRIPTION
# Description
* base64 encode license key strings, since secret manifests that use `data` expect an encoded string.
