### PR TITLE
Bump version to 7.7.1

### DIFF
--- a/charts/netobserv/Chart.yaml
+++ b/charts/netobserv/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: netobserv
 description: ElastiFlow NetObserv
 type: application
-version: 0.4.3
-appVersion: 7.5.2
+version: 0.4.4
+appVersion: 7.5.3
 
 keywords:
   - netflow

--- a/charts/netobserv/Chart.yaml
+++ b/charts/netobserv/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: netobserv
 description: ElastiFlow NetObserv
 type: application
-version: 0.4.4
-appVersion: 7.5.3
+version: 0.4.5
+appVersion: 7.7.1
 
 keywords:
   - netflow

--- a/charts/netobserv/templates/deployment.yaml
+++ b/charts/netobserv/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
               {{- end }}
             - name: GEOIPUPDATE_DB_DIR
               value: /data
+            - name: GEOIPUPDATE_FREQUENCY
+              {{- if .Values.maxmind.geoipEnabled }}
+              value: "{{ .Values.maxmind.geoipUpdateFrequency }}"
+              {{- end }}
           volumeMounts:
             - name: geolite2-data
               mountPath: /data

--- a/charts/netobserv/values.yaml
+++ b/charts/netobserv/values.yaml
@@ -118,6 +118,8 @@ maxmind:
   # Enabling geoip will look up the country, subdivisions (regions), city, and
   # postal code associated with IPv4 and IPv6 addresses.
   geoipEnabled: false
+  # When geoip is enabled, this specifies the frequency in hours to update the MaxMind geoip database.
+  geoipUpdateFrequency: 24
   accountId: ""
   licenseKey: ""
 


### PR DESCRIPTION
# Description
* bump collector default version to 7.7.1
* add `geoipUpdateFrequency` option to maxmind config.

## Changes summary
* add configurable `geoipUpdateFrequency` to resolve https://github.com/elastiflow/helm-chart-netobserv/issues/40
