### PR TITLE
Resolve #56, where geoip blocks init

### DIFF
--- a/charts/netobserv/templates/deployment.yaml
+++ b/charts/netobserv/templates/deployment.yaml
@@ -56,10 +56,6 @@ spec:
               {{- end }}
             - name: GEOIPUPDATE_DB_DIR
               value: /data
-            {{- if .Values.maxmind.geoipEnabled }}
-            - name: GEOIPUPDATE_FREQUENCY
-              value: "{{ .Values.maxmind.geoipUpdateFrequency }}"
-            {{- end }}
           volumeMounts:
             - name: geolite2-data
               mountPath: /data
@@ -138,11 +134,11 @@ spec:
           ports: {{ .Values.ports | toYaml | nindent 12 }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}         
+            {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}         
+            {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -195,6 +191,10 @@ spec:
               {{- end }}
             - name: GEOIPUPDATE_DB_DIR
               value: /data
+            {{- if .Values.maxmind.geoipEnabled }}
+            - name: GEOIPUPDATE_FREQUENCY
+              value: "{{ .Values.maxmind.geoipUpdateFrequency }}"
+            {{- end }}
           volumeMounts:
             - name: geolite2-data
               mountPath: /data


### PR DESCRIPTION
# Description
Let's the initContainer terminate by removing `GEOIPUPDATE_FREQUENCY` environment variable (as the init requires). Applied it to the maxmind-geoipupdate update container. Resolves #56 

## Changes summary
Moved `GEOIPUPDATE_FREQUENCY` from init-maxmind-geoipupdate to maxmind-geoipupdate.
