### PR TITLE
feat(netobserv-flow): bump collector appVersion to 7.23.0

### DIFF
--- a/charts/netobserv-flow/Chart.yaml
+++ b/charts/netobserv-flow/Chart.yaml
@@ -3,7 +3,7 @@ name: netobserv-flow
 description: ElastiFlow NetObserv Flow Collector
 type: application
 version: 0.9.0
-appVersion: 7.22.0
+appVersion: 7.23.0
 icon: https://artifacthub.io/image/a7c44004-9982-4ba1-a4c9-c626340d3d38@2x
 sources:
   - https://github.com/elastiflow/helm-chart-netobserv


### PR DESCRIPTION
## Changed

- Set `appVersion` to 7.23.0 so new installs default to the `elastiflow/flow-collector:7.23.0` image.